### PR TITLE
Fix Vault request error handling

### DIFF
--- a/internal/encrypt/vault.go
+++ b/internal/encrypt/vault.go
@@ -184,7 +184,9 @@ func (c *vaultWrapper) withRefreshToken(isEncrypt bool, key, data string) (strin
 			result, err = c.decryptLocked(key, data)
 		}
 	}()
-	if err == nil || c.config.Token != "" {
+	if err != nil {
+		return result, err
+	} else if c.config.Token != "" {
 		return result, nil
 	}
 	_, ok := err.(*forbiddenError)


### PR DESCRIPTION
## Description

Otherwise errors during request are ignored, which leads to strange behavior hiddenly.

Please include: 
- [X] a summary of the change and which issue is fixed
- [X] relevant motivation and context
- [X] any dependencies that are required for this change

Fixes # (issue)

## Type of change

Please check options that are relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Previously i got `unable to transform key "/registry/secrets/default/default-token-c5ngc": invalid padding on input` because all encrypted data were an empty string. After my fix All secrets worked well.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
