### PR TITLE
introduction of end-2-end worfklow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,11 +12,6 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ main ]
   schedule:
     - cron: '26 16 * * 5'
 

--- a/.github/workflows/e2e-on-pr.yml
+++ b/.github/workflows/e2e-on-pr.yml
@@ -3,6 +3,8 @@
 name: end-2-end build
 
 on:
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
   
 permissions:

--- a/.github/workflows/go-lint-scan-pull_request.yaml
+++ b/.github/workflows/go-lint-scan-pull_request.yaml
@@ -1,8 +1,6 @@
 name: golangci-lint
 
 on:
-  pull_request:
-    branches: [ main ]
   workflow_dispatch:
 
 permissions: 

--- a/.github/workflows/gosec-scanner-on-pull_request.yaml
+++ b/.github/workflows/gosec-scanner-on-pull_request.yaml
@@ -1,9 +1,6 @@
 name: "gosec"
 
 on:
-  pull_request:
-    branches: [ main ]
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -9,11 +9,6 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
-#   pull_request:
-#     # The branches below must be a subset of the branches above
-#     branches: [ main ]
-#   schedule:
-#     - cron: '40 18 * * 1'
 
 permissions:
   contents: read
@@ -26,18 +21,11 @@ jobs:
     name: Build
     runs-on: "ubuntu-18.04"
     steps:
-#       - name: Checkout code
-#         uses: actions/checkout@v3
-
-#       - name: Build an image from Dockerfile
-#         run: |
-#           docker build -t docker.io/my-organization/my-app:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@2a2157eb22c08c9a1fac99263430307b8d1bc7a2
         with:
-#           image-ref: 'docker.io/my-organization/my-app:${{ github.sha }}'
-          image-ref: ghcr.io/ondat/trousseau:v1.1.1
+          image-ref: ghcr.io/ondat/trousseau:${{ github.sha }}'
           format: 'template'
           template: '@/contrib/sarif.tpl'
           output: 'trivy-results.sarif'


### PR DESCRIPTION
This workflow replace the separate golangci-lint, gosecscan, and codeql-analysis with one workflow that:

- golangci-lint (permissive - it will not fail the workflow if there is some linting issues): same as previously, it will check for proper golang formating and best practices 
- gosec-scanning (enforced - if there is an issue it fails the worfklow), sams as previously, it will check for any golang security flaws 
- image-build (enforced - if there is an issue it fails the workflow), new job, it will create a container image with the commit hash as tag and push on ghrc.io/ondat/trousseau 

This last job will ease the availability of a built for testing. 

The next stage will be do push the image to a kubernetes cluster and perform a burn/hammer test.

The new end-2-end worfklow jobs have separate configuration files with an underscore prefix to differentiate them with the old ones. 

Note: 
- no changes made on the scorecards-analysis workflow 
- codeql is on schedule only to reduce the number of GH action minutes