### PR TITLE
bump opentelemetry prometheus exporter module to 0.21.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/spf13/viper v1.12.0
 	github.com/stretchr/testify v1.7.2
 	go.opentelemetry.io/otel v1.7.0
-	go.opentelemetry.io/otel/exporters/metric/prometheus v0.20.0
+	go.opentelemetry.io/otel/exporters/metric/prometheus v0.21.0
 	go.opentelemetry.io/otel/metric v0.21.0
 	go.uber.org/zap v1.21.0
 	google.golang.org/grpc v1.46.2


### PR DESCRIPTION
comparing dependaboot auto PR with manual one as these are failing the e-2-e build workflow
link with old PR #59 