### PR TITLE
Select decryption backend via Roundrobin

### DIFF
--- a/.github/workflows/e2e-debug-on-pr.yml
+++ b/.github/workflows/e2e-debug-on-pr.yml
@@ -1,4 +1,4 @@
-name: AWS KMS e2e on pr
+name: Debug e2e on pr
 
 on:
   pull_request:

--- a/trousseau/go.mod
+++ b/trousseau/go.mod
@@ -10,6 +10,7 @@ replace (
 
 require (
 	github.com/ondat/trousseau v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.7.2
 	google.golang.org/grpc v1.46.2
 	k8s.io/apiserver v0.24.1
 	k8s.io/klog/v2 v2.60.1
@@ -18,6 +19,7 @@ require (
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.2.3 // indirect
@@ -25,11 +27,11 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
-	github.com/stretchr/testify v1.7.2 // indirect
 	go.opentelemetry.io/otel v1.7.0 // indirect
 	go.opentelemetry.io/otel/exporters/metric/prometheus v0.20.0 // indirect
 	go.opentelemetry.io/otel/internal/metric v0.21.0 // indirect
@@ -47,4 +49,5 @@ require (
 	google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/trousseau/pkg/server/sort.go
+++ b/trousseau/pkg/server/sort.go
@@ -1,0 +1,44 @@
+package server
+
+import "sort"
+
+type Roundrobin struct {
+	lock  chan bool
+	names []string
+	index int
+}
+
+func (r *Roundrobin) Next() []string {
+	if len(r.names) == 0 {
+		return make([]string, 0)
+	}
+
+	r.lock <- true
+	defer func() {
+		<-r.lock
+	}()
+
+	r.index++
+	if r.index > len(r.names)-1 {
+		r.index = 0
+	}
+
+	if r.index == 0 {
+		return r.names
+	}
+
+	return append(r.names[r.index:], r.names[:r.index]...)
+}
+
+// NewRoundrobin creates a new Roundrobin selector.
+func NewRoundrobin(providers []string) *Roundrobin {
+	names := append(make([]string, 0, len(providers)), providers...)
+
+	sort.Strings(names)
+
+	return &Roundrobin{
+		lock:  make(chan bool, 1),
+		names: names,
+		index: -1,
+	}
+}

--- a/trousseau/pkg/server/sort_test.go
+++ b/trousseau/pkg/server/sort_test.go
@@ -1,0 +1,26 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRoundrobin(t *testing.T) {
+	expectedResults := [][]string{
+		{"a", "b", "c", "d"},
+		{"b", "c", "d", "a"},
+		{"c", "d", "a", "b"},
+		{"d", "a", "b", "c"},
+	}
+
+	rr := NewRoundrobin([]string{"a", "b", "c", "d"})
+
+	for i := 0; i < 3; i++ {
+		for _, expected := range expectedResults {
+			actual := rr.Next()
+
+			assert.Equal(t, expected, actual, "Roundrobin failed")
+		}
+	}
+}


### PR DESCRIPTION
This change is part of Multi KMS support. Original implementation iterated over providers in the same order each time. This new change introduces the Round-robin algorithm to balance decryption requests between backends.