### PR TITLE
Delete socket file before listen and terminate if socket is missing

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -210,44 +210,39 @@ tasks:
     deps:
       - bin-dir:init
     cmds:
-      - rm -rf bin/run/proxy.socket
       - docker rm -f trousseau-proxy || true
       - docker run -d --name trousseau-proxy --rm -v $PWD/bin/run:/opt/vault-kms $DOCKER_REGISTRY/$IMAGE_NAME:proxy-$IMAGE_VERSION
   docker:run:debug:
     deps:
       - bin-dir:init
     cmds:
-      - rm -rf bin/run/debug/debug.socket
       - docker rm -f trousseau-debug || true
       - docker run -d --name trousseau-debug --rm -v $PWD/bin/run:/opt/vault-kms $DOCKER_REGISTRY/$IMAGE_NAME:debug-$IMAGE_VERSION
   docker:run:vault:
     deps:
       - bin-dir:init
     cmds:
-      - rm -rf bin/run/vault/vault.socket
       - docker rm -f trousseau-local-vault || true
       - docker run -d --name=trousseau-local-vault --cap-add=IPC_LOCK -e 'VAULT_DEV_ROOT_TOKEN_ID=vault-kms-demo' vault
       - sleep 5
       - docker exec -e VAULT_ADDR=http://127.0.0.1:8200 trousseau-local-vault vault login vault-kms-demo
       - docker exec -e VAULT_ADDR=http://127.0.0.1:8200 trousseau-local-vault vault secrets enable transit
       - docker rm -f trousseau-vault || true
-      - docker run -d --name trousseau-vault --rm --network=container:trousseau-local-vault -v $PWD/tests/e2e/kuttl/kube-v{{.KIND_CLUSTER_VERSION}}/vault.yaml:/opt/vault-kms/vault/config.yaml -v $PWD/bin/run:/opt/vault-kms $DOCKER_REGISTRY/$IMAGE_NAME:vault-$IMAGE_VERSION -v=3
+      - docker run -d --name trousseau-vault --rm --network=container:trousseau-local-vault -v $PWD/tests/e2e/kuttl/kube-v{{.KIND_CLUSTER_VERSION}}/vault.yaml:/etc/config.yaml -v $PWD/bin/run:/opt/vault-kms $DOCKER_REGISTRY/$IMAGE_NAME:vault-$IMAGE_VERSION --config-file-path=/etc/config.yaml -v=3
   docker:run:awskms:
     deps:
       - bin-dir:init
     cmds:
-      - rm -rf bin/run/awskms/awskms.socket
       - docker rm -f trousseau-local-aws || true
       - docker run --name trousseau-local-aws --rm --hostname localhost.localstack.cloud -d -e SERVICES=kms -e HOSTNAME=localhost.localstack.cloud -e HOSTNAME_EXTERNAL=localhost.localstack.cloud -e DEFAULT_REGION=eu-west-1 -e KMS_PROVIDER=kms-local -p 4566:4566 -p 4510-4559:4510-4559 localstack/localstack:0.14.4
       - sleep 5
       - 'printf %"s\n" "endpoint: https://localhost.localstack.cloud:4566" "profile: trousseau-local-aws" "keyArn: $(docker exec trousseau-local-aws awslocal kms create-key | grep Arn | cut -d''"'' -f4)" > tests/e2e/kuttl/kube-v{{.KIND_CLUSTER_VERSION}}/awskms.yaml'
       - docker rm -f trousseau-awskms || true
-      - docker run -d --name trousseau-awskms --rm --network=container:trousseau-local-aws -v $PWD/tests/e2e/kuttl/kube-v{{.KIND_CLUSTER_VERSION}}/aws-credentials.ini:/.aws/credentials -v $PWD/tests/e2e/kuttl/kube-v{{.KIND_CLUSTER_VERSION}}/awskms.yaml:/opt/vault-kms/awskms/config.yaml -v $PWD/bin/run:/opt/vault-kms $DOCKER_REGISTRY/$IMAGE_NAME:awskms-$IMAGE_VERSION -v=3
+      - docker run -d --name trousseau-awskms --rm --network=container:trousseau-local-aws -v $PWD/tests/e2e/kuttl/kube-v{{.KIND_CLUSTER_VERSION}}/aws-credentials.ini:/.aws/credentials -v $PWD/tests/e2e/kuttl/kube-v{{.KIND_CLUSTER_VERSION}}/awskms.yaml:/etc/config.yaml -v $PWD/bin/run:/opt/vault-kms $DOCKER_REGISTRY/$IMAGE_NAME:awskms-$IMAGE_VERSION --config-file-path=/etc/config.yaml -v=3
   docker:run:trousseau:
     deps:
       - bin-dir:init
     cmds:
-      - rm -rf bin/run/trousseau.socket
       - docker rm -f trousseau-core || true
       - docker run -d --name trousseau-core --rm -v $PWD/bin/run:/opt/vault-kms $DOCKER_REGISTRY/$IMAGE_NAME:trousseau-$IMAGE_VERSION {{.ENABLED_PROVIDERS}} -v=3
   go:tidy:
@@ -424,7 +419,6 @@ tasks:
       - bin-dir:init
       - go:tidy:proxy
     cmds:
-      - rm -rf ../bin/run/proxy.socket
       - go run main.go --listen-addr unix://../bin/run/proxy.socket --trousseau-addr ../bin/run/trousseau.socket
   go:run:debug:
     dir: providers/debug
@@ -432,7 +426,6 @@ tasks:
       - bin-dir:init
       - go:tidy:debug
     cmds:
-      - rm -rf ../../bin/run/debug/debug.socket
       - go run main.go --listen-addr unix://../../bin/run/debug/debug.socket
   go:run:vault:
     dir: providers/vault
@@ -440,7 +433,6 @@ tasks:
       - bin-dir:init
       - go:tidy:vault
     cmds:
-      - rm -rf ../../bin/run/vault/vault.socket
       - go run -ldflags '-X github.com/ondat/trousseau/pkg/utils.SecretLogDivider=1' main.go --config-file-path ../../tests/e2e/kuttl/kube-v{{.KIND_CLUSTER_VERSION}}/vault.yaml --listen-addr unix://../../bin/run/vault/vault.socket --zap-encoder=console --v=5
   go:run:awskms:
     dir: providers/awskms
@@ -448,7 +440,6 @@ tasks:
       - bin-dir:init
       - go:tidy:awskms
     cmds:
-      - rm -rf ../../bin/run/awskms/awskms.socket
       - go run -ldflags '-X github.com/ondat/trousseau/pkg/utils.SecretLogDivider=1' main.go --config-file-path ../../tests/e2e/kuttl/kube-v{{.KIND_CLUSTER_VERSION}}/awskms.yaml --listen-addr unix://../../bin/run/awskms/awskms.socket --zap-encoder=console --v=5
   go:run:trousseau:
     dir: trousseau
@@ -456,7 +447,6 @@ tasks:
       - bin-dir:init
       - go:tidy:trousseau
     cmds:
-      - rm -rf ../bin/run/trousseau.socket
       - go run -ldflags '-X github.com/ondat/trousseau/pkg/utils.SecretLogDivider=1' main.go {{.ENABLED_PROVIDERS}} --socket-location ../bin/run --listen-addr unix://../bin/run/trousseau.socket --zap-encoder=console --v=5
   go:e2e-tests:
     desc: e2e tests

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,6 +1,11 @@
 package utils
 
-import "strconv"
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+)
 
 var (
 	// -X github.com/ondat/trousseau/pkg/utils.SecretLogDivider=1
@@ -28,4 +33,32 @@ func SecretToLog(s string) string {
 	}
 
 	return string(b[:len(b)/secretLogDivider]) + suffix
+}
+
+// RemoveFile removes given file.
+func RemoveFile(path string) error {
+	path = filepath.Clean(path)
+
+	if _, err := os.Stat(path); err != nil {
+		return nil
+	}
+
+	return os.Remove(path)
+}
+
+func WatchFile(path string) <-chan error {
+	errChan := make(chan error)
+	ticker := time.NewTicker(time.Second)
+
+	go func() {
+		for {
+			<-ticker.C
+
+			if _, err := os.Stat(path); err != nil {
+				errChan <- err
+			}
+		}
+	}()
+
+	return errChan
 }

--- a/providers/awskms/main.go
+++ b/providers/awskms/main.go
@@ -62,6 +62,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = utils.RemoveFile(addr); err != nil {
+		klog.ErrorS(err, "unable to delete socket file", "file", addr)
+	}
+
 	listener, err := net.Listen(proto, addr)
 	if err != nil {
 		klog.Errorln(err)
@@ -69,6 +73,11 @@ func main() {
 	}
 
 	klog.InfoS("Listening for connections", "address", listener.Addr())
+
+	go func() {
+		klog.Errorln(<-utils.WatchFile(addr))
+		os.Exit(1)
+	}()
 
 	if err := s.Serve(listener); err != nil {
 		klog.Errorln(err)

--- a/providers/debug/main.go
+++ b/providers/debug/main.go
@@ -45,6 +45,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = utils.RemoveFile(addr); err != nil {
+		klog.ErrorS(err, "unable to delete socket file", "file", addr)
+	}
+
 	listener, err := net.Listen(proto, addr)
 	if err != nil {
 		klog.Errorln(err)
@@ -52,6 +56,11 @@ func main() {
 	}
 
 	klog.InfoS("Listening for connections", "address", listener.Addr())
+
+	go func() {
+		klog.Errorln(<-utils.WatchFile(addr))
+		os.Exit(1)
+	}()
 
 	if err := s.Serve(listener); err != nil {
 		klog.Errorln(err)

--- a/providers/vault/main.go
+++ b/providers/vault/main.go
@@ -56,6 +56,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = utils.RemoveFile(addr); err != nil {
+		klog.ErrorS(err, "unable to delete socket file", "file", addr)
+	}
+
 	listener, err := net.Listen(proto, addr)
 	if err != nil {
 		klog.Errorln(err)
@@ -63,6 +67,11 @@ func main() {
 	}
 
 	klog.InfoS("Listening for connections", "address", listener.Addr())
+
+	go func() {
+		klog.Errorln(<-utils.WatchFile(addr))
+		os.Exit(1)
+	}()
 
 	if err := s.Serve(listener); err != nil {
 		klog.Errorln(err)

--- a/proxy/main.go
+++ b/proxy/main.go
@@ -30,6 +30,10 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
+	if err = utils.RemoveFile(addr); err != nil {
+		log.Printf("Unable to delete socket file: %s: %s\n", addr, err.Error())
+	}
+
 	listener, err := net.Listen(proto, addr)
 	if err != nil {
 		log.Fatal(err.Error())

--- a/tests/e2e/kuttl/kube-v1.23/awskms.yaml
+++ b/tests/e2e/kuttl/kube-v1.23/awskms.yaml
@@ -1,3 +1,3 @@
 endpoint: https://localhost.localstack.cloud:4566
 profile: trousseau-local-aws
-keyArn: arn:aws:kms:eu-west-1:000000000000:key/6d6221f8-cee1-4d6d-b803-498bd6792a6f
+keyArn: arn:aws:kms:eu-west-1:000000000000:key/2cd914cd-5350-4b90-abb9-d8cd882cf6f3

--- a/trousseau/main.go
+++ b/trousseau/main.go
@@ -97,11 +97,22 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = utils.RemoveFile(addr); err != nil {
+		klog.ErrorS(err, "unable to delete socket file", "file", addr)
+	}
+
 	listener, err := net.Listen(proto, addr)
 	if err != nil {
 		klog.Errorln(err)
 		os.Exit(1)
 	}
+
+	klog.InfoS("Listening for connections", "address", listener.Addr())
+
+	go func() {
+		klog.Errorln(<-utils.WatchFile(addr))
+		os.Exit(1)
+	}()
 
 	kmsServer, err := server.New(*decryptPreference, *socketLocation, enabledProviders, *socketTimeout)
 	if err != nil {


### PR DESCRIPTION
## Description

This change has two functions:
 * Delete existing socket file during startup to avoid file already existing errors
 * Watch socket file, and if someone accidentally deleted it, terminate to process. It is up to the orchestrator to restart service

Fixes # [(102)](https://github.com/ondat/trousseau/issues/102)

## Type of change

Please check options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manually, I started component and removed socket file.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [-] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
